### PR TITLE
Add torch FAD based on fadtk

### DIFF
--- a/audiocraft/metrics/__init__.py
+++ b/audiocraft/metrics/__init__.py
@@ -8,7 +8,7 @@
 # flake8: noqa
 from .clap_consistency import CLAPTextConsistencyMetric, TextConsistencyMetric
 from .chroma_cosinesim import ChromaCosineSimilarityMetric
-from .fad import FrechetAudioDistanceMetric
+from .fad import FrechetAudioDistanceMetric, TorchFrechetAudioDistanceMetric
 from .kld import KLDivergenceMetric, PasstKLDivergenceMetric
 from .rvm import RelativeVolumeMel
 from .visqol import ViSQOL

--- a/audiocraft/solvers/builders.py
+++ b/audiocraft/solvers/builders.py
@@ -256,12 +256,19 @@ def get_visqol(cfg: omegaconf.DictConfig) -> metrics.ViSQOL:
     return metrics.ViSQOL(**kwargs)
 
 
-def get_fad(cfg: omegaconf.DictConfig) -> metrics.FrechetAudioDistanceMetric:
+def get_fad(cfg: omegaconf.DictConfig) -> tp.Union[metrics.FrechetAudioDistanceMetric, metrics.TorchFrechetAudioDistanceMetric]:
     """Instantiate Frechet Audio Distance metric from config."""
-    kwargs = dict_from_config(cfg.tf)
-    xp = dora.get_xp()
-    kwargs['log_folder'] = xp.folder
-    return metrics.FrechetAudioDistanceMetric(**kwargs)
+    if cfg.model == 'tf':
+        kwargs = dict_from_config(cfg.tf)
+        xp = dora.get_xp()
+        kwargs['log_folder'] = xp.folder
+        return metrics.FrechetAudioDistanceMetric(**kwargs)
+    elif cfg.model == 'torch':
+        kwargs = cfg.get("torch", None)
+        kwargs = dict_from_config(kwargs) if kwargs is not None else dict()
+        xp = dora.get_xp()
+        kwargs['log_folder'] = xp.folder
+        return metrics.TorchFrechetAudioDistanceMetric(**kwargs)
 
 
 def get_kldiv(cfg: omegaconf.DictConfig) -> metrics.KLDivergenceMetric:

--- a/config/solver/audiogen/survey_baseline.yaml
+++ b/config/solver/audiogen/survey_baseline.yaml
@@ -53,7 +53,7 @@ generate:
     top_p: 0.0
 
 optim:
-  epochs: 100
+  epochs: 75
   optimizer: adamw
   lr: 5e-4
   ema:
@@ -69,3 +69,7 @@ schedule:
   inverse_sqrt:
     warmup: 3000
     warmup_init_lr: 0.0
+
+metrics:
+  fad:
+    model: torch

--- a/config/solver/audiogen/survey_baseline.yaml
+++ b/config/solver/audiogen/survey_baseline.yaml
@@ -27,7 +27,7 @@ conditioners:
       name: t5-base
 
 dataset:
-  batch_size: 128  # matching AudioGen paper setup (256 * mix_p=0.5 = 128)
+  batch_size: 64  # matching AudioGen paper setup (256 * mix_p=0.5 = 128)
   num_workers: 10
   segment_duration: 10
   min_segment_ratio: 1.0
@@ -36,7 +36,7 @@ dataset:
   external_metadata_source: null
   # sample mixing augmentation at train time
   train:
-    batch_size: 256  # matching AudioGen paper setup
+    batch_size: 128  # matching AudioGen paper setup
     aug_p: 0.5  # perform audio mixing 50% of the time
     mix_p: 0.5  # proportion of batch items mixed together
                 # important: note that this will reduce the
@@ -53,7 +53,7 @@ generate:
     top_p: 0.0
 
 optim:
-  epochs: 75
+  epochs: 100
   optimizer: adamw
   lr: 5e-4
   ema:


### PR DESCRIPTION
Install following - https://github.com/microsoft/fadtk?tab=readme-ov-file:
```
pip install fadtk
```

Run with (for example):
```
dora run solver=audiogen/survey_baseline execute_only=evaluate compression_model_checkpoint=//pretrained/facebook/encodec_32khz sample_rate=32000 dataset.batch_size=8 dataset.train.batch_size=16 continue_from=//sig/7c1a9f1c/ solver/audiogen/evaluation=objective_eval evaluate.metrics.kld=false evaluate.metrics.fad=true +evaluate.remove_text_conditioning=False
```